### PR TITLE
HCSA-1153 pg_dump backup script improvements

### DIFF
--- a/pg_dump/pg_dump
+++ b/pg_dump/pg_dump
@@ -18,9 +18,9 @@ DBS=$(psql -h ${DB_HOST} -U ${POSTGRES_USER} -l -t --field-separator=': ' -A -x 
 for d in ${DBS};do
   if [ "${DELETE}" == "t" ];then
     echo "Deleting old dumps for ${d}" >> ${LOG}
-    # keep 1 day => delete all but the last 10 dumps
-    echo "$(ls -rt ${DUMP_PATH}/${d}.*.gz | head -n -10)" >> ${LOG}
-    ls -rt ${DUMP_PATH}/${d}.*.gz | head -n -10 | xargs -r rm
+    # keep 1 day => delete all but the last 9 dumps
+    echo "$(ls -rt ${DUMP_PATH}/${d}.*.gz | head -n -9)" >> ${LOG}
+    ls -rt ${DUMP_PATH}/${d}.*.gz | head -n -9 | xargs -r rm
   fi
 
   BAK="${DUMP_PATH}/$d.${EXT}.sql"
@@ -33,6 +33,7 @@ for d in ${DBS};do
   if [ $? -eq 0 ];then
     pigz ${BAK}
     if [ $? -eq 0 ];then
+      # keep 9 + 1 = 10 backups - eventually
       echo "Backup of ${d} to ${BAK}.gz completed." >> ${LOG}
       continue
     fi

--- a/pg_dump/pg_dump
+++ b/pg_dump/pg_dump
@@ -29,7 +29,6 @@ for d in ${DBS};do
     continue
   fi
   pg_dump -h ${DB_HOST} -U ${POSTGRES_USER} ${d} > ${BAK}
-  grep -q "PostgreSQL database dump complete" ${BAK}
   if [ $? -eq 0 ];then
     pigz ${BAK}
     if [ $? -eq 0 ];then

--- a/pg_dump/pg_dump
+++ b/pg_dump/pg_dump
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 # if parameter 1 is set use it as extension to the create file names"
 if [ -n "$1" ]; then


### PR DESCRIPTION
* rely on pg_dump exit code (0) - to verify that it was success - do not double check it by grepping the whole sql dump file - it is time consuming
*  ensure that exactly last 10 backup files are stored (rotated) at the very end of script execution
* get rid of debugging (-x option) in sh execution on PROD - for security reason