### PR TITLE
Solution (2) for fixed postgres 10-alpine version

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,8 +1,9 @@
-FROM postgres:10.16-alpine
+FROM postgres:10-alpine
 
 RUN apk update --no-cache && \
     apk upgrade --no-cache && \
-    apk add --no-cache openssl curl tzdata py-pip postgresql-dev postgresql-contrib make gcc musl-dev py3-psutil && \
+    apk add --no-cache --repository  http://dl-cdn.alpinelinux.org/alpine/v3.13/main/ 'musl<1.2.2-r3' 'musl-dev<1.2.2-r3' && \
+    apk add --no-cache openssl curl tzdata py-pip postgresql-dev postgresql-contrib make gcc py3-psutil && \
     pip install pgxnclient && \
     pgxnclient install temporal_tables
     


### PR DESCRIPTION
After research the reason was found and the bug is caused by recent changes in musl library referred here:
https://gitlab-test.alpinelinux.org/alpine/aports/-/issues/12321
The solution now - is to keep fixed version of musl and musl-dev library - instead of freezing the whole postgres image. 
