### PR TITLE
#320 Update the Keycloak docker image to 16.1.0

### DIFF
--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,4 +1,4 @@
-FROM jboss/keycloak:12.0.1
+FROM jboss/keycloak:16.1.0
 
 ARG SORMAS_URL=https://github.com/hzi-braunschweig/SORMAS-Project/releases/download/
 

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -10,7 +10,7 @@
 
 # Container Keycloak
 
-The Keycloak container is built from `jboss/keycloak:11.0.0`.
+The Keycloak container is built from `jboss/keycloak:16.1.0`.
 
 It loads a predefined `SORMAS` Realm, `sormas` theme and a custom SPI `sormas-keycloak-service-provider`.
 


### PR DESCRIPTION
Fixes #320 

Has to be merged at the same time with https://github.com/hzi-braunschweig/SORMAS-Project/issues/5901