### PR TITLE
HSP-2764 placing weld-integration.jar in Payara to get rid of (No valid EE environment for injection) message

### DIFF
--- a/payara/Dockerfile
+++ b/payara/Dockerfile
@@ -11,4 +11,4 @@ RUN wget --no-check-certificate -O /tmp/payara-5.2021.10.zip "https://search.mav
   && rm /tmp/payara-5.2021.10.zip
 
 # remove this below patch after upgraded Payara to higher than 5.2021.10 once (No valid EE environment) is FIXED
-RUN wget --no-check-certificate -O /opt/payara5/glassfish/modules/weld-integration.jar "https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/sormas-base/setup/glassfish-modules/weld-integration.jar"
+RUN wget --no-check-certificate -O /opt/payara5/glassfish/modules/weld-integration.jar "https://raw.githubusercontent.com/hzi-braunschweig/SORMAS-Project/development/sormas-base/setup/glassfish-modules/weld-integration.jar"

--- a/payara/Dockerfile
+++ b/payara/Dockerfile
@@ -9,3 +9,5 @@ RUN wget --no-check-certificate -O /tmp/payara-5.2021.10.zip "https://search.mav
   && unzip -q -o /tmp/payara-5.2021.10.zip -d /opt/ \
   && rm -R /opt/payara5/glassfish/domains \
   && rm /tmp/payara-5.2021.10.zip
+
+RUN wget --no-check-certificate -O /opt/payara5/glassfish/glassfish-modules/weld-integration.jar "https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/sormas-base/setup/glassfish-modules/weld-integration.jar"

--- a/payara/Dockerfile
+++ b/payara/Dockerfile
@@ -11,4 +11,4 @@ RUN wget --no-check-certificate -O /tmp/payara-5.2021.10.zip "https://search.mav
   && rm /tmp/payara-5.2021.10.zip
 
 # remove this below patch after upgraded Payara to higher than 5.2021.10 once (No valid EE environment) is FIXED
-RUN wget --no-check-certificate -O /opt/payara5/glassfish/glassfish-modules/weld-integration.jar "https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/sormas-base/setup/glassfish-modules/weld-integration.jar"
+RUN wget --no-check-certificate -O /opt/payara5/glassfish/modules/weld-integration.jar "https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/sormas-base/setup/glassfish-modules/weld-integration.jar"

--- a/payara/Dockerfile
+++ b/payara/Dockerfile
@@ -10,4 +10,5 @@ RUN wget --no-check-certificate -O /tmp/payara-5.2021.10.zip "https://search.mav
   && rm -R /opt/payara5/glassfish/domains \
   && rm /tmp/payara-5.2021.10.zip
 
+# remove this below patch after upgraded Payara to higher than 5.2021.10 once (No valid EE environment) is FIXED
 RUN wget --no-check-certificate -O /opt/payara5/glassfish/glassfish-modules/weld-integration.jar "https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/sormas-base/setup/glassfish-modules/weld-integration.jar"


### PR DESCRIPTION
HSP-2764 placing weld-integration.jar in Payara to get rid of (No valid EE environment for injection) message